### PR TITLE
Reorganize important markets

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -241,10 +241,10 @@
             }
         },
         {
-            "base": "0xbtc",
-            "quote": "vsf",
+            "base": "weth",
+            "quote": "dai",
             "config": {
-                "basePrecision": 2,
+                "basePrecision": 6,
                 "pricePrecision": 6
             }
         },
@@ -257,26 +257,26 @@
             }
         },
         {
-            "base": "vsf",
-            "quote": "weth",
-            "config": {
-                "basePrecision": 0,
-                "pricePrecision": 8
-            }
-        },
-        {
-            "base": "weth",
-            "quote": "dai",
-            "config": {
-                "basePrecision": 6,
-                "pricePrecision": 6
-            }
-        },
-        {
             "base": "usdc",
             "quote": "dai",
             "config": {
                 "basePrecision": 2,
+                "pricePrecision": 8
+            }
+        },
+        {
+            "base": "vsf",
+            "quote": "0xbtc",
+            "config": {
+                "basePrecision": 2,
+                "pricePrecision": 6
+            }
+        },
+        {
+            "base": "vsf",
+            "quote": "weth",
+            "config": {
+                "basePrecision": 0,
                 "pricePrecision": 8
             }
         },

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -241,6 +241,14 @@
             }
         },
         {
+            "base": "0xbtc",
+            "quote": "vsf",
+            "config": {
+                "basePrecision": 2,
+                "pricePrecision": 6
+            }
+        },
+        {
             "base": "weth",
             "quote": "dai",
             "config": {
@@ -262,14 +270,6 @@
             "config": {
                 "basePrecision": 2,
                 "pricePrecision": 8
-            }
-        },
-        {
-            "base": "vsf",
-            "quote": "0xbtc",
-            "config": {
-                "basePrecision": 2,
-                "pricePrecision": 6
             }
         },
         {


### PR DESCRIPTION
~-- changes 0xBTC/VSF to VSF/0xBTC~ reverted here eecef789bc386df75007c74ea6509bfeba4171ff
-- puts more active and important markets into top

-- syncs development branch with VeriSafe/0xChange

See

![0xbtc-market](https://user-images.githubusercontent.com/34014106/81036951-4e22be00-8ea1-11ea-8b94-f19324f0f7ea.png)
![eth-market](https://user-images.githubusercontent.com/34014106/81036963-57ac2600-8ea1-11ea-90e9-aff59a065068.png)
![dai-market](https://user-images.githubusercontent.com/34014106/81036967-5aa71680-8ea1-11ea-8f7c-0fa620d8552f.png)
![all-market-up](https://user-images.githubusercontent.com/34014106/81037179-0fd9ce80-8ea2-11ea-9481-bf48b49a74cc.png)

